### PR TITLE
add rsync in apk add instruction for Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ COPY . .
 
 RUN apk --no-cache update && \
     apk --no-cache upgrade && \
-    apk add build-base git cyrus-sasl-dev
+    apk add build-base git cyrus-sasl-dev rsync
 
 RUN  dos2unix build.sh && ./build.sh && \
      dos2unix test.sh && \


### PR DESCRIPTION
fixes #22 
In Dockerfile, add the "rsync" in "apk add" instruction to have the "rsync" utility installed on top of the Alpine layer