### PR TITLE
Change Travis behaviour for importing go packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ deploy/
 dist/
 
 artifact_go.sh
+*.exe

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,13 +12,7 @@ addons:
     packages:
       - mongodb-org-server
 
-before_install:
-  # fix travis working folder (see http://www.ruflin.com/2015/08/13/fix-for-travis-ci-failure-in-forked-golang-repositories/)
-  - mkdir -p $HOME/gopath/src/github.com/tidepool-org/hydrophone
-  - rsync -az ${TRAVIS_BUILD_DIR}/ $HOME/gopath/src/github.com/tidepool-org/hydrophone/
-  - export TRAVIS_BUILD_DIR=$HOME/gopath/src/github.com/tidepool-org/hydrophone
-  - cd $HOME/gopath/src/github.com/tidepool-org/hydrophone
-
+go_import_path: github.com/tidepool-org/hydrophone
 
 deploy:
   # Control deployment by setting a value for `on`. Setting the `branch`


### PR DESCRIPTION
The Travis build is problematic by default because of the way Go imports the packages and dependencies for the build (see http://www.ruflin.com/2015/08/13/fix-for-travis-ci-failure-in-forked-golang-repositories/). Travis code was changed to prevent from this bad behaviour ( see #1 ).
This piece of code was problematic as the Travis setup was done twice.
This PR is a proposal for changing this "before_install" script by the "go_import_path" instruction (https://docs.travis-ci.com/user/languages/go/#go-import-path) 

Fix #33 