### PR TITLE
PT-301 fix patient password reset link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ This API sends notifications to users for things like forgotten passwords, initi
 
 ## [Unreleased]
 
+### Changed
+- PT-301 Fix wrong link to detailed instructions for Patient Reset Password. Complete link is now entirely in configuration
+- Support URL has been changed in base configuration to be a mailto instead of https website
+
 ## dblp.0.3.0 - 2019-03-21
 
 ### Added

--- a/api/hydrophoneApi.go
+++ b/api/hydrophoneApi.go
@@ -39,7 +39,7 @@ type (
 		AssetURL                  string `json:"assetUrl"`                  // used for location of the images
 		I18nTemplatesPath         string `json:"i18nTemplatesPath"`         // where are the templates located?
 		AllowPatientResetPassword bool   `json:"allowPatientResetPassword"` // true means that patients can reset their password, false means that only clinicianc can reset their password
-		WebHelp                   string `json:"webHelp"`                   // URL of the help web site that is used to give instructions to reset password for patients
+		PatientPasswordResetURL   string `json:"patientPasswordResetUrl"`   // URL of the help web site that is used to give instructions to reset password for patients
 	}
 
 	group struct {
@@ -277,7 +277,7 @@ func (a *Api) createAndSendNotification(conf *models.Confirmation, content map[s
 	content["WebURL"] = a.Config.WebURL
 	content["SupportURL"] = a.Config.SupportURL
 	content["AssetURL"] = a.Config.AssetURL
-	content["WebHelp"] = a.Config.WebHelp
+	content["PatientPasswordResetURL"] = a.Config.PatientPasswordResetURL
 
 	// Retrieve the template from all the preloaded templates
 	template, ok := a.templates[templateName]

--- a/env.sh
+++ b/env.sh
@@ -30,11 +30,11 @@ export TIDEPOOL_HYDROPHONE_SERVICE='{
     "hydrophone" : {
         "serverSecret": "This needs to be the same secret everywhere. YaHut75NsK1f9UKUXuWqxNN0RUwHFBCy",
         "webUrl": "http://localhost:3000",
-        "supportUrl": "https://diabeloop.zendesk.com",
+        "supportUrl": "mailto:yourloops@diabeloop.fr",
         "assetUrl": "https://s3-us-west-2.amazonaws.com/tidepool-dev-asset",
         "i18nTemplatesPath": "/go/src/github.com/tidepool-org/hydrophone/templates",
         "allowPatientResetPassword": true,
-        "WebHelp": "https://diabeloop.zendesk.com"
+        "patientPasswordResetUrl": "https://diabeloop.zendesk.com/hc/articles/360021365373"
     },
     "sesEmail" : {
         "serverEndpoint":"https://email.us-west-2.amazonaws.com",

--- a/templates/html/patient_password_reset.html
+++ b/templates/html/patient_password_reset.html
@@ -59,7 +59,7 @@
                           <tr>
                             <td>
                       <![endif]-->
-                      <a class="btn primary" href="{{.WebHelp}}/patient-password-reset" style="text-decoration:none;display:inline-block;font-family:'Ubuntu', sans-serif;border-radius:4px;padding:10px 20px;background-color:#6fc3bb;font-size:16px;font-weight:bold;color:#ffffff;margin-left:5px;margin-right:5px;margin-bottom:10px;">
+                      <a class="btn primary" href="{{.PatientPasswordResetURL}}" style="text-decoration:none;display:inline-block;font-family:'Ubuntu', sans-serif;border-radius:4px;padding:10px 20px;background-color:#6fc3bb;font-size:16px;font-weight:bold;color:#ffffff;margin-left:5px;margin-right:5px;margin-bottom:10px;">
                         {{ .PatientPasswordResetClick }}
                   </a>
                       <!--[if (gte mso 9)|(IE)]>

--- a/templates/locales/en.yaml
+++ b/templates/locales/en.yaml
@@ -28,7 +28,7 @@ PatientPasswordResetHello: "Hello,"
 PatientPasswordResetRequest: "You requested a password reset."
 PatientPasswordResetDidNotRequest: "If you didn't request this, please ignore this email."
 PatientPasswordResetByDevice: "Resetting your password has to be done on your Diabeloop device."
-PatientPasswordResetClick: "Please click here to see the detailled instructions"
+PatientPasswordResetClick: "Please click here to see the detailed instructions"
 
 # CareTeamInvite
 # (email for those that invited someone to join medical crew)

--- a/templates/source/patient_password_reset.html
+++ b/templates/source/patient_password_reset.html
@@ -52,7 +52,7 @@
                   <tr>
                   <td>
                   <![endif]-->
-                  <a class="btn primary" href="{{ .WebHelp }}/patient-password-reset">
+                  <a class="btn primary" href="{{ .PatientPasswordResetURL }}">
                     {{ .PatientPasswordResetClick }}
                   </a>
                   <!--[if (gte mso 9)|(IE)]>


### PR DESCRIPTION
Review the logic so the complete link for "patient password reset" instructions is given in configuration.
Configuration item has been renamed from "WebHelp" to "PatientPasswordResetURL".

Also, supportLink has been changed in the configuration so it is now a mailto and not a https.

