### PR TITLE
Reintroduce serverEndpoint override capability

### DIFF
--- a/.vscode/launch.json.template
+++ b/.vscode/launch.json.template
@@ -1,6 +1,4 @@
-   // Use IntelliSense to learn about possible attributes.
-   // Hover to view descriptions of existing attributes.
-   // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+{   
    "version": "0.2.0",
    "configurations": [
        {
@@ -11,7 +9,7 @@
            "program": "${workspaceRoot}",
            "env": {
                "TIDEPOOL_HYDROPHONE_ENV":"{ \"hakken\": { \"host\": \"localhost:8000\" }, \"gatekeeper\": { \"serviceSpec\": { \"type\": \"static\", \"hosts\": [\"http://localhost:9123\"] } }, \"seagull\": { \"serviceSpec\": { \"type\": \"static\", \"hosts\": [\"http://localhost:9120\"] } }, \"highwater\": { \"serviceSpec\": { \"type\": \"static\", \"hosts\": [\"http://localhost:9191\"] }, \"name\": \"highwater\", \"metricsSource\" : \"hydrophone-local\", \"metricsVersion\" : \"v0.0.1\" }, \"shoreline\": { \"serviceSpec\": { \"type\": \"static\", \"hosts\": [\"http://localhost:9107\"] }, \"name\": \"hydrophone\", \"secret\": \"<<hydrophone_server_secret>>\", \"tokenRefreshInterval\": \"1h\" } }",
-               "TIDEPOOL_HYDROPHONE_SERVICE":"{ \"service\": { \"service\": \"hydrophone\", \"protocol\": \"http\", \"host\": \"localhost:9157\", \"keyFile\": \"config/key.pem\", \"certFile\": \"config/cert.pem\" }, \"mongo\": { \"connectionString\": \"mongodb://<<user_personal>>:<<password_personal>>@localhost:27017/confirm?authSource=admin\" }, \"hydrophone\" : { \"serverSecret\": \"<<server_secret>>\", \"webUrl\": \"http://localhost:3000\", \"supportUrl\": \"mailto:<<email_to_support>>\", \"assetUrl\": \"<<url_to_s3_for_images>>\", \"i18nTemplatesPath\": \"D:\/git\/mdblp\/go\/src\/github.com\/tidepool-org\/hydrophone\/templates\", \"allowPatientResetPassword\": false, \"patientPasswordResetUrl\": \"https://diabeloop.zendesk.com/hc/articles/360021365373\" }, \"sesEmail\" : { \"region\": \"eu-west-1\", \"fromAddress\" : \"<<support_email_from>>\" } }"
+               "TIDEPOOL_HYDROPHONE_SERVICE":"{ \"service\": { \"service\": \"hydrophone\", \"protocol\": \"http\", \"host\": \"localhost:9157\", \"keyFile\": \"config/key.pem\", \"certFile\": \"config/cert.pem\" }, \"mongo\": { \"connectionString\": \"mongodb://<<user_personal>>:<<password_personal>>@localhost:27017/confirm?authSource=admin\" }, \"hydrophone\" : { \"serverSecret\": \"<<server_secret>>\", \"webUrl\": \"http://localhost:3000\", \"supportUrl\": \"mailto:<<email_to_support>>\", \"assetUrl\": \"<<url_to_s3_for_images>>\", \"i18nTemplatesPath\": \"D:\/git\/mdblp\/go\/src\/github.com\/tidepool-org\/hydrophone\/templates\", \"allowPatientResetPassword\": false, \"patientPasswordResetUrl\": \"https://diabeloop.zendesk.com/hc/articles/360021365373\" }, \"sesEmail\" : { \"region\": \"eu-west-1\", \"fromAddress\" : \"<<support_email_from>>\", \"serverEndpoint\" : \"<<serverEndpointIfNeeded>>\" } }"
                // Use this below to override local AWS credentials. Otherwise local credentials will be used so the user/profile needs to have rights for sending emails
                // "AWS_PROFILE":"${NON_DEFAULT_PROFILE}" for using a .aws/credentials non default profile
                // OR

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,16 +1,47 @@
 Hydrophone Dev Docs
 ===
 
+# Configuration
+
+See [.vscode/launch.json.template](../.vscode/launch.json.template) or [env.sh](../env.sh) for examples.
+
+## TIDEPOOL_HYDROPHONE_ENV
+
+Contains configuration about the stack where Hydrophone is running.
+
+## TIDEPOOL_HYDROPHONE_SERVICE
+
+Contains configuration necessary to run Hydrophone as a microservice.
+
+### sesEmail
+
+This configuration item is a JSON string that uses the following:
+- _fromAddress_: the email address to be used as the email sender
+- _region_: the AWS region to be used for AWS SES service
+- _serverEndpoint_: (if present) this will be used to override the AWS SES default endpoint (can be used in conjunction with MockServer for example) 
+
+**!!! WARNING !!! Since last Tidepool integration, AWS Credentials to send emails are not used here anymore. See [below](#aws-credentials).**
+
+### hydrophone
+
+This configuration item is a JSON string that uses the following:
+- _serverSecret_: the secret to be used to connect to shoreline and get server token
+- _webUrl_: URL for the links to "Blip" in the emails
+- _supportUrl_: URL for the links to "Support" in the emails
+- _assetUrl_: where public artefacts needed by emails are present (like images)
+- _i18nTemplatesPath_: where the HTML templates for emails reside
+- _allowPatientResetPassword_: toggle to allow/disallow patient to reset their password (if disallowed, a specific mail is sent to the patient)
+- _patientPasswordResetUrl_: URL where the instructions for the patient to reset his email are
+  
 # AWS Credentials
 
   An AWS Credential is a pair {access key;secret access key}.
   
-  Since last Tidepool upstream integration (v0.9.0), AWS Credentials to send emails are not challenged in the _TIDEPOOL_HYDROPHONE_SERVICE/sesEMail_ configuration anymore. Also, _serverEndpoint_ is not needed anymore and has been replaced by _region_. _fromAddress_ still is challenged there.  
-  (see [.vscode/launch.json.template](.vscode/launch.json.template) or [env.sh](env.sh) for example)
-
+  Since last Tidepool upstream integration, AWS Credentials to send emails are not challenged in the _TIDEPOOL_HYDROPHONE_SERVICE/sesEMail_ configuration anymore. 
+  
   Moreover, Hydrophone does not use any mechanism to push specific AWS credentials when instanciating a new AWS SES Client. I.e. there is no overriding of credentials done by the code itself.
 
-  As a matter of fact, it is necessary to provide AWS credentials differently. The credentials provider chain looks for credentials in this order. It stops when one working credential is found:
+  **As a matter of fact**, it is necessary to provide AWS credentials differently. The credentials provider chain looks for credentials in this order. It stops when one working credential is found:
   - Environment variables (_AWS_ACCESS_KEY_ID_ and _AWS_SECRET_ACCESS_KEY_)
   - Shared Credentials file present in home directory (use environment variable _AWS_PROFILE_ if several profiles are present and you don't want the default one to be used)
   - It the application is running on an EC2 instance, IAM roles for the said instance
@@ -143,11 +174,10 @@ with
 
 # Testing
 
-## Local Email Testing
+## Mocking AWS SES
 
-Testing locally requires that you have a temporary AWS SES credentials provide to you by the backend engineering team lead. These credentials must be kept private, as soon as testing is complete, the engineering team lead mush be informed so as to revoke them.
-
-Extreme care must be taken to not commit this to out public git repo. If that were to happen, for any reason or lenght of time, the backend engineering team lead MUST be notified immediately.
+In order to test emails without actually sending them, it is possible to mock the AWS SES service. This can be achieved by using [MockServer](http://www.mock-server.com/) that is capturing all the HTTP traffic and acting upon email pattern matching.
+For that, it is possible to override the AWS SES endpoint using _TIDEPOOL_HYDROPHONE_SERVICE/sesEmail/serverEndpoint_ item. See [above](#sesemail)
 
 ## Multiple Email Client Testing
 

--- a/env.sh
+++ b/env.sh
@@ -37,13 +37,14 @@ export TIDEPOOL_HYDROPHONE_SERVICE='{
         "serverSecret": "This needs to be the same secret everywhere. YaHut75NsK1f9UKUXuWqxNN0RUwHFBCy",
         "webUrl": "http://localhost:3000",
         "supportUrl": "mailto:yourloops@diabeloop.fr",
-        "assetUrl": "https://s3-us-west-2.amazonaws.com/tidepool-dev-asset",
+        "assetUrl": "https://s3-eu-west-1.amazonaws.com/com.diabeloop.public-assets",
         "i18nTemplatesPath": "/go/src/github.com/tidepool-org/hydrophone/templates",
         "allowPatientResetPassword": true,
         "patientPasswordResetUrl": "https://diabeloop.zendesk.com/hc/articles/360021365373"
     },
     "sesEmail" : {
         "region":"eu-west-1",
-        "fromAddress" : "${SUPPORT_EMAIL_ADDR}"
+        "fromAddress": "${SUPPORT_EMAIL_ADDR}"
+        "serverEndpoint": ""
     }
 }'


### PR DESCRIPTION
I reintroduced the capacity to override the AWS SES endpoint to accomodate with Mock Server.