### PR TITLE
PT-449 fix invitations error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,11 @@ go:
 go_import_path: github.com/tidepool-org/hydrophone
 
 before_install:
-  sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 2930ADAE8CAF5059EE73BB4B58712A2291FA4AD5;
-  echo "deb [ arch=amd64 ] https://repo.mongodb.org/apt/ubuntu trusty/mongodb-org/3.6 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-3.6.list;
-  sudo apt-get update;
-  sudo apt-get install --allow-unauthenticated -y mongodb-org=3.6.12 mongodb-org-server=3.6.12 mongodb-org-shell=3.6.12 mongodb-org-mongos=3.6.12 mongodb-org-tools=3.6.12;
-  sudo service mongod start;
+  - sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 2930ADAE8CAF5059EE73BB4B58712A2291FA4AD5;
+  - echo "deb [ arch=amd64 ] https://repo.mongodb.org/apt/ubuntu trusty/mongodb-org/3.6 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-3.6.list;
+  - sudo apt-get update;
+  - sudo apt-get install --allow-unauthenticated -y mongodb-org=3.6.12 mongodb-org-server=3.6.12 mongodb-org-shell=3.6.12 mongodb-org-mongos=3.6.12 mongodb-org-tools=3.6.12;
+  - sudo service mongod start;
   # fix travis working folder (see http://www.ruflin.com/2015/08/13/fix-for-travis-ci-failure-in-forked-golang-repositories/)
   - mkdir -p $HOME/gopath/src/github.com/tidepool-org/hydrophone
   - rsync -az ${TRAVIS_BUILD_DIR}/ $HOME/gopath/src/github.com/tidepool-org/hydrophone/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 Hydrophone is the module responsible of sending emails. 
 This API sends notifications to users for things like forgotten passwords, initial signup, and invitations. 
 
+## unreleased 
+
+- PT-449 Fix Error when several invitations are sent to a person who does not have an account yet. The first invitation can be accepted but the remaining ones cannot be.
+
 ## dblp.0.3.2 - 2019-04-17
 
 ### Changed

--- a/api/invite.go
+++ b/api/invite.go
@@ -203,6 +203,10 @@ func (a *Api) AcceptInvite(res http.ResponseWriter, req *http.Request, vars map[
 
 		validationErrors := []error{}
 
+		/* get the invitee details so that we can use its username/email to
+		*  validate it when the invitation was sent while inviteeID was not
+		*  yet created.
+		 */
 		inviteeDetails, err := a.sl.GetUser(inviteeID, a.sl.TokenProvide())
 		if err != nil {
 			log.Printf("AcceptInvite InviteeID not found %s err[%s]", STATUS_ERR_FINDING_USER, err.Error())

--- a/api/invite.go
+++ b/api/invite.go
@@ -203,9 +203,19 @@ func (a *Api) AcceptInvite(res http.ResponseWriter, req *http.Request, vars map[
 
 		validationErrors := []error{}
 
+		inviteeDetails, err := a.sl.GetUser(inviteeID, a.sl.TokenProvide())
+		if err != nil {
+			log.Printf("AcceptInvite InviteeID not found %s err[%s]", STATUS_ERR_FINDING_USER, err.Error())
+			a.sendModelAsResWithStatus(
+				res,
+				&status.StatusError{Status: status.NewStatus(http.StatusForbidden, statusForbiddenMessage)},
+				http.StatusForbidden,
+			)
+			return
+		}
 		conf.ValidateStatus(models.StatusPending, &validationErrors).
 			ValidateType(models.TypeCareteamInvite, &validationErrors).
-			ValidateUserID(inviteeID, &validationErrors).
+			ValidateUserID(inviteeID, inviteeDetails.Username, &validationErrors).
 			ValidateCreatorID(invitorID, &validationErrors)
 
 		if len(validationErrors) > 0 {

--- a/artifact.sh
+++ b/artifact.sh
@@ -1,6 +1,6 @@
 #!/bin/sh -e
 
-wget -q -O artifact_go.sh 'https://raw.githubusercontent.com/mdblp/tools/dbl/artifact/artifact_go.sh'
+wget -q -O artifact_go.sh 'https://raw.githubusercontent.com/mdblp/tools/dblp/artifact/artifact_go.sh'
 chmod +x artifact_go.sh
 
 . ./version.sh

--- a/models/confirmation.go
+++ b/models/confirmation.go
@@ -156,6 +156,9 @@ func (c *Confirmation) ValidateCreatorID(expectedCreatorID string, validationErr
 func (c *Confirmation) ValidateUserID(expectedUserID string, expectedEmail string, validationErrors *[]error) *Confirmation {
 
 	if expectedEmail == c.Email && expectedUserID != c.UserId {
+		// corner case where UserID is not available for new accounts.
+		// in that case we rely on the email and we override the UserId with
+		// the expectedUserID
 		c.UserId = expectedUserID
 	}
 	if expectedUserID != c.UserId {

--- a/models/confirmation.go
+++ b/models/confirmation.go
@@ -146,6 +146,13 @@ func (c *Confirmation) ValidateCreatorID(expectedCreatorID string, validationErr
 	return c
 }
 
+// ValidateUserID
+// Validate the user based on UserID and Email (entered as username)
+//
+// expectedUserID: userid of the account
+// expectedEmail: username of the account (email)
+// validationErrors: array of error filled in case of error, empty if everything is ok
+//
 func (c *Confirmation) ValidateUserID(expectedUserID string, expectedEmail string, validationErrors *[]error) *Confirmation {
 
 	if expectedEmail == c.Email && expectedUserID != c.UserId {

--- a/models/confirmation.go
+++ b/models/confirmation.go
@@ -146,7 +146,11 @@ func (c *Confirmation) ValidateCreatorID(expectedCreatorID string, validationErr
 	return c
 }
 
-func (c *Confirmation) ValidateUserID(expectedUserID string, validationErrors *[]error) *Confirmation {
+func (c *Confirmation) ValidateUserID(expectedUserID string, expectedEmail string, validationErrors *[]error) *Confirmation {
+
+	if expectedEmail == c.Email && expectedUserID != c.UserId {
+		c.UserId = expectedUserID
+	}
 	if expectedUserID != c.UserId {
 		*validationErrors = append(
 			*validationErrors,


### PR DESCRIPTION
This error occurs when at least 2 invitations are sent to an account that does not yet exist. 
The first invitation can be approved but the second one is stuck