### PR TITLE
[PT-715] Implement an smtp client for hydrophone 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+dist: trusty
+
 sudo: false
 
 language: go
@@ -54,6 +56,7 @@ deploy:
 
 services:
   - docker
+  - mongodb
 
 script:
   - ./test.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,10 @@
 Hydrophone is the module responsible for sending emails.
 This API sends notifications to users for things like forgotten passwords, initial signup, and invitations.
 
-## [0.5.0] - 2019-10-02
+## 0.6.0 - 2019-10-11
+- PT-175: implement an STMP notifier to offer an alternative to aws ses.
+
+## 0.5.0 - 2019-10-02
 ### Added
 - PT-636 Add a new route for sanity check email to ensure configuration is allowing emails to actually be sent
 

--- a/clients/smtpNotifier.go
+++ b/clients/smtpNotifier.go
@@ -1,0 +1,48 @@
+package clients
+
+import (
+	"log"
+	"net/smtp"
+)
+
+type (
+	// SmtpNotifier
+	SmtpNotifier struct {
+		Config *SmtpNotifierConfig
+	}
+
+	// SmtpNotifierConfig contains the static configuration for the smtp service
+	// Credentials come from the environment and are not passed in via configuration variables.
+	SmtpNotifierConfig struct {
+		From     string `json:"fromAddress"`
+		Server   string `json:"serverAdress"`
+		User     string `json:"user"`
+		Password string `json:"password"`
+	}
+)
+
+//NewSmtpNotifier creates a new SMTP notifier (using standard smtp to send emails)
+func NewSmtpNotifier(cfg *SmtpNotifierConfig) (*SmtpNotifier, error) {
+	return &SmtpNotifier{
+		Config: cfg,
+	}, nil
+}
+
+// Send a message to a list of recipients with a given subject
+func (c *SmtpNotifier) Send(to []string, subject string, msg string) (int, string) {
+	// Set up authentication information.
+	auth := smtp.PlainAuth("", c.Config.User, c.Config.Password, c.Config.Server)
+	body := []byte("To: " + to[0] + "\r\n" +
+
+		"Subject: " + subject + "\r\n" +
+
+		"\r\n" +
+
+		msg + "\r\n")
+	err := smtp.SendMail(c.Config.Server, auth, c.Config.From, to, body)
+	if err != nil {
+		log.Println(err.Error())
+		return 400, err.Error()
+	}
+	return 200, "OK"
+}

--- a/clients/smtpNotifier.go
+++ b/clients/smtpNotifier.go
@@ -16,6 +16,7 @@ type (
 	SmtpNotifierConfig struct {
 		From     string `json:"fromAddress"`
 		Server   string `json:"serverAdress"`
+		Port     string `json:"serverPort"`
 		User     string `json:"user"`
 		Password string `json:"password"`
 	}
@@ -32,7 +33,7 @@ func NewSmtpNotifier(cfg *SmtpNotifierConfig) (*SmtpNotifier, error) {
 func (c *SmtpNotifier) Send(to []string, subject string, msg string) (int, string) {
 	// Set up authentication information.
 	var auth smtp.Auth
-	// If not user is provided, then do not try to authenticate to the server (for dev only)
+	// If no user is provided, then do not try to authenticate to the server (for dev only)
 	if c.Config.User != "" {
 		auth = smtp.PlainAuth("", c.Config.User, c.Config.Password, c.Config.Server)
 	}
@@ -43,7 +44,7 @@ func (c *SmtpNotifier) Send(to []string, subject string, msg string) (int, strin
 
 		mime + "\r\n" +
 		msg + "\r\n")
-	err := smtp.SendMail(c.Config.Server, auth, c.Config.From, to, body)
+	err := smtp.SendMail(c.Config.Server+":"+c.Config.Port, auth, c.Config.From, to, body)
 	if err != nil {
 		log.Println(err.Error())
 		return 400, err.Error()

--- a/clients/smtpNotifier.go
+++ b/clients/smtpNotifier.go
@@ -31,13 +31,17 @@ func NewSmtpNotifier(cfg *SmtpNotifierConfig) (*SmtpNotifier, error) {
 // Send a message to a list of recipients with a given subject
 func (c *SmtpNotifier) Send(to []string, subject string, msg string) (int, string) {
 	// Set up authentication information.
-	auth := smtp.PlainAuth("", c.Config.User, c.Config.Password, c.Config.Server)
+	var auth smtp.Auth
+	// If not user is provided, then do not try to authenticate to the server (for dev only)
+	if c.Config.User != "" {
+		auth = smtp.PlainAuth("", c.Config.User, c.Config.Password, c.Config.Server)
+	}
+	mime := "MIME-version: 1.0;\nContent-Type: text/html; charset=\"UTF-8\";\n\n"
 	body := []byte("To: " + to[0] + "\r\n" +
 
 		"Subject: " + subject + "\r\n" +
 
-		"\r\n" +
-
+		mime + "\r\n" +
 		msg + "\r\n")
 	err := smtp.SendMail(c.Config.Server, auth, c.Config.From, to, body)
 	if err != nil {

--- a/docs/README.md
+++ b/docs/README.md
@@ -44,8 +44,21 @@ This configuration item is a JSON string that uses the following:
 - _allowPatientResetPassword_: toggle to allow/disallow patient to reset their password (if disallowed, a specific mail is sent to the patient)
 - _patientPasswordResetUrl_: URL where the instructions for the patient to reset his email are
 
-### sesEmail
+### notifierType
+Hydrophone currently support 2 sending methods:
+* AWS SES (default)
+* SMTP
 
+The mail service is specified in the configuration variable `TIDEPOOL_HYDROPHONE_SERVICE.notifierType`. It accepts `ses` or `smtp`.  
+
+### smtpEmail
+This configuration item is a JSON string that uses the following:
+- _fromAddress_: the email address to be used as the email sender
+- _serverAdress_: the smtp server adress
+- _user_: (if present) this will be used to authenticate to the smtp server
+- _password_: (if present) this will be used to authenticate to the smtp server
+
+### sesEmail
 This configuration item is a JSON string that uses the following:
 - _fromAddress_: the email address to be used as the email sender
 - _region_: the AWS region to be used for AWS SES service

--- a/docs/README.md
+++ b/docs/README.md
@@ -49,7 +49,7 @@ Hydrophone currently support 2 sending methods:
 * AWS SES (default)
 * SMTP
 
-The mail service is specified in the configuration variable `TIDEPOOL_HYDROPHONE_SERVICE.notifierType`. It accepts `ses` or `smtp`.  
+The mail service is specified in the configuration variable `TIDEPOOL_HYDROPHONE_SERVICE.notifierType`. It accepts `ses` or `smtp` (`ses` by default).  
 
 ### smtpEmail
 This configuration item is a JSON string that uses the following:

--- a/env.sh
+++ b/env.sh
@@ -42,6 +42,7 @@ export TIDEPOOL_HYDROPHONE_SERVICE='{
         "allowPatientResetPassword": true,
         "patientPasswordResetUrl": "https://diabeloop.zendesk.com/hc/articles/360021365373"
     },
+    "notifierType": "ses",
     "sesEmail" : {
         "region":"eu-west-1",
         "fromAddress": "${SUPPORT_EMAIL_ADDR}"

--- a/env.sh
+++ b/env.sh
@@ -47,5 +47,12 @@ export TIDEPOOL_HYDROPHONE_SERVICE='{
         "region":"eu-west-1",
         "fromAddress": "${SUPPORT_EMAIL_ADDR}"
         "serverEndpoint": ""
+    },
+    "smtpEmail": {
+        "fromAddress": "${SUPPORT_EMAIL_ADDR}",
+        "serverAdress": "smtp.ethereal.email",
+        "serverPort": "587",
+        "user": "",
+        "password": ""
     }
 }'

--- a/hydrophone.go
+++ b/hydrophone.go
@@ -26,11 +26,12 @@ type (
 	// Config is the configuration for the service
 	Config struct {
 		clients.Config
-		Service disc.ServiceListing   `json:"service"`
-		Mongo   mongo.Config          `json:"mongo"`
-		Api     api.Config            `json:"hydrophone"`
-		Ses     sc.SesNotifierConfig  `json:"sesEmail"`
-		Smtp    sc.SmtpNotifierConfig `json:"smtpEmail"`
+		Service      disc.ServiceListing   `json:"service"`
+		Mongo        mongo.Config          `json:"mongo"`
+		Api          api.Config            `json:"hydrophone"`
+		Ses          sc.SesNotifierConfig  `json:"sesEmail"`
+		Smtp         sc.SmtpNotifierConfig `json:"smtpEmail"`
+		NotifierType string                `json:"notifierType"`
 	}
 )
 
@@ -110,17 +111,27 @@ func main() {
 		WithHttpClient(httpClient).
 		Build()
 
-	/*
-	 * hydrophone setup
-	 */
+		/*
+		 * hydrophone setup
+		 */
+	log.Printf("try to create the email notifier %s", config.NotifierType)
 	store := sc.NewMongoStoreClient(&config.Mongo)
-	mail, err := sc.NewSesNotifier(&config.Ses)
 
-	if err != nil {
-		log.Fatal(err)
+	// Create a notifier based on configuration
+	var mail sc.Notifier
+	var mailErr error
+	switch config.NotifierType {
+	case "ses":
+		mail, mailErr = sc.NewSesNotifier(&config.Ses)
+	case "smtp":
+		mail, mailErr = sc.NewSmtpNotifier(&config.Smtp)
+	default:
+		log.Fatalf("the mail system provided in the configuration (%s) is invalid", config.NotifierType)
+	}
+	if mailErr != nil {
+		log.Fatal(mailErr)
 	} else {
-		// SES Client can be created even though no credential is found
-		log.Printf("SES client created %s", mail.SES.ClientInfo)
+		log.Printf("Mail client %s created", config.NotifierType)
 	}
 
 	// Create collection of pre-compiled templates

--- a/hydrophone.go
+++ b/hydrophone.go
@@ -26,10 +26,11 @@ type (
 	// Config is the configuration for the service
 	Config struct {
 		clients.Config
-		Service disc.ServiceListing  `json:"service"`
-		Mongo   mongo.Config         `json:"mongo"`
-		Api     api.Config           `json:"hydrophone"`
-		Mail    sc.SesNotifierConfig `json:"sesEmail"`
+		Service disc.ServiceListing   `json:"service"`
+		Mongo   mongo.Config          `json:"mongo"`
+		Api     api.Config            `json:"hydrophone"`
+		Ses     sc.SesNotifierConfig  `json:"sesEmail"`
+		Smtp    sc.SmtpNotifierConfig `json:"smtpEmail"`
 	}
 )
 
@@ -43,11 +44,11 @@ func main() {
 
 	region, found := os.LookupEnv("REGION")
 	if found {
-		config.Mail.Region = region
+		config.Ses.Region = region
 	}
 
-	if config.Mail.Region == "" {
-		config.Mail.Region = "us-west-2"
+	if config.Ses.Region == "" {
+		config.Ses.Region = "us-west-2"
 	}
 
 	// server secret may be passed via a separate env variable to accomodate easy secrets injection via Kubernetes
@@ -113,7 +114,7 @@ func main() {
 	 * hydrophone setup
 	 */
 	store := sc.NewMongoStoreClient(&config.Mongo)
-	mail, err := sc.NewSesNotifier(&config.Mail)
+	mail, err := sc.NewSesNotifier(&config.Ses)
 
 	if err != nil {
 		log.Fatal(err)

--- a/hydrophone.go
+++ b/hydrophone.go
@@ -114,12 +114,15 @@ func main() {
 		/*
 		 * hydrophone setup
 		 */
-	log.Printf("try to create the email notifier %s", config.NotifierType)
 	store := sc.NewMongoStoreClient(&config.Mongo)
 
 	// Create a notifier based on configuration
 	var mail sc.Notifier
 	var mailErr error
+	//defaults the mail exchange service to ses
+	if config.NotifierType == "" {
+		config.NotifierType = "ses"
+	}
 	switch config.NotifierType {
 	case "ses":
 		mail, mailErr = sc.NewSesNotifier(&config.Ses)


### PR DESCRIPTION
Not everyone want/can use AWS and SMTP is then one of the easiest solutions to send emails.

Question: Are you ok with the way the configuration is managed (switch between SES and SMTP)
Should we add tests for smtp (how? with a mock server?)