### PR TITLE
PT-1139 add openapi generation and deployment in pipeline

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,11 @@ go:
   - 1.12.7
 
 env:
-  - GO111MODULE=on
+  global: 
+    - GO111MODULE=on
+    - BUILD_OPENAPI_DOC=true
 
 go_import_path: github.com/tidepool-org/hydrophone
-
 
 before_install:
   - sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 2930ADAE8CAF5059EE73BB4B58712A2291FA4AD5;
@@ -36,24 +37,36 @@ deploy:
   # Control deployment by setting a value for `on`. Setting the `branch`
   # option to `master` means Travis will only attempt a deployment on
   # builds of your repo's master branch (e.g., after you merge a PR).
-  on:
-    tags: true
-  #branch: dblp
-  provider: s3
-  # You can refer to environment variables from Travis repo settings!
-  access_key_id: $AWS_ACCESS_KEY_ID
-  secret_access_key: $AWS_SECRET_ACCESS_KEY
-  region: $AWS_DEFAULT_REGION
-  # Name of the S3 bucket to which your site should be uploaded.
-  bucket: $AWS_BUCKET
-  # Prevent Travis from deleting your built site so it can be uploaded.
-  skip_cleanup: true
-  # Path of the source directory containing your built site.
-  local_dir: deploy
-  # Path to a directory containing your built site.
-  upload-dir: deploy
-  # Set the Cache-Control header.
-  cache_control: "max-age=21600"
+  - provider: s3
+    on:
+      tags: true
+    
+    # You can refer to environment variables from Travis repo settings!
+    access_key_id: $AWS_ACCESS_KEY_ID
+    secret_access_key: $AWS_SECRET_ACCESS_KEY
+    region: $AWS_DEFAULT_REGION
+    # Name of the S3 bucket to which your site should be uploaded.
+    bucket: $AWS_BUCKET
+    # Prevent Travis from deleting your built site so it can be uploaded.
+    skip_cleanup: true
+    # Path of the source directory containing your built site.
+    local_dir: deploy
+    # Path to a directory containing your built site.
+    upload-dir: deploy
+    # Set the Cache-Control header.
+    cache_control: "max-age=21600"
+  # Deploy doc
+  - provider: s3
+    on:
+      tags: true
+    access_key_id: $AWS_ACCESS_KEY_ID
+    secret_access_key: $AWS_SECRET_ACCESS_KEY
+    region: $AWS_DEFAULT_REGION
+    bucket: com.diabeloop.yourloops.doc
+    skip_cleanup: true
+    local-dir: docs/openapi
+    upload-dir: openapi/hydrophone
+    cache_control: "max-age=21600"
 
 services:
   - docker
@@ -62,5 +75,4 @@ services:
 script:
   - ./test.sh
   - ./artifact.sh
-  - ./doc.sh
   - ./artifact-preview.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ This API sends notifications to users for things like forgotten passwords, initi
 - PT-899: Preview emails
 - PT-995: Document the api using openApi and swaggo
 
+### Changed
+- PT-1139: Add openapi generation and deployment in pipeline
+
 ## 0.7.0 - 2019-10-18
 ### Added
 - PT-671: Display the application version number on the status endpoint (/status).  

--- a/artifact.sh
+++ b/artifact.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 
-wget -q -O artifact_go.sh 'https://raw.githubusercontent.com/mdblp/tools/dblp/artifact/artifact_go.sh'
+wget -q -O artifact_go.sh 'https://raw.githubusercontent.com/mdblp/tools/feature/add_openapi_go/artifact/artifact_go.sh'
 chmod +x artifact_go.sh
 
 . ./version.sh

--- a/artifact.sh
+++ b/artifact.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 
-wget -q -O artifact_go.sh 'https://raw.githubusercontent.com/mdblp/tools/feature/add_openapi_go/artifact/artifact_go.sh'
+wget -q -O artifact_go.sh 'https://raw.githubusercontent.com/mdblp/tools/dblp/artifact/artifact_go.sh'
 chmod +x artifact_go.sh
 
 . ./version.sh

--- a/build.sh
+++ b/build.sh
@@ -5,7 +5,7 @@ mkdir dist
 
 # generate version number
 if [ -n "${TRAVIS_TAG:-}" ]; then
-    VERSION_BASE=${TRAVIS_TAG}  
+    VERSION_BASE=${TRAVIS_TAG}
 else 
     VERSION_BASE=$(git describe --abbrev=0 --tags 2> /dev/null || echo 'dblp.0.0.0')
 fi
@@ -26,4 +26,3 @@ cp start.sh dist/
 
 echo "Push email templates"
 rsync -av --progress templates dist/ --exclude '*.go' --exclude 'preview'
-

--- a/buildDoc.sh
+++ b/buildDoc.sh
@@ -1,0 +1,21 @@
+#!/bin/sh -eu
+# Generate OpenAPI documentation
+GOPATH=${GOPATH:-~/go}
+echo "Using GOPATH: ${GOPATH}"
+
+if [ ! -x "$GOPATH/bin/swag" ]; then
+  echo "Getting swag..."
+  go get -u github.com/swaggo/swag/cmd/swag
+fi
+
+$GOPATH/bin/swag --version
+$GOPATH/bin/swag init --generalInfo hydrophone.go --output docs
+
+# When tag is present, openapi doc is renamed before being deployed to S3
+if [ -n "${TRAVIS_TAG:-}" ]; then
+    APP="${TRAVIS_REPO_SLUG#*/}"
+    APP_TAG="${APP}-${TRAVIS_TAG}"
+    mkdir docs/openapi
+    mv docs/swagger.json docs/openapi/${APP_TAG}-swagger.json
+fi
+

--- a/doc.sh
+++ b/doc.sh
@@ -1,4 +1,0 @@
-#!/bin/sh -eu
-
-go get -u github.com/swaggo/swag/cmd/swag
-$GOPATH/bin/swag init -g ./hydrophone.go


### PR DESCRIPTION
It has dependency on "tools" where PR needs to be merged (https://github.com/mdblp/tools/pull/14). Once "tools" is merged, we can update the artifact_go.sh location in this PR.

I tried many different solutions found in Travis doc to move only the swagger.json file into S3 but was not successful at any of those. So I decided to create a specific folder (docs/openapi) containing only the swagger.json to be sent to S3 through 'local-dir'