### PR TITLE
PT-1341 Review signup link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This API sends notifications to users for things like forgotten passwords, initi
 ## Unreleased
 ### Changed
 - PT-1278 Integrate Tidepool master for hydrophone
+- PT-1341 Change signup link when invited
 
 ## 0.8.1 - 2020-04-07
 ### Engineering use

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 Hydrophone is the module responsible for sending emails.
 This API sends notifications to users for things like forgotten passwords, initial signup, and invitations.
 
-## Unreleased
+## 0.9.0 - 2020-05-18
 ### Changed
 - PT-1278 Integrate Tidepool master for hydrophone
 - PT-1341 Change signup link when invited

--- a/api/invite.go
+++ b/api/invite.go
@@ -499,7 +499,7 @@ func (a *Api) SendInvite(res http.ResponseWriter, req *http.Request, vars map[st
 						fullName = invite.Creator.Profile.Patient.FullName
 					}
 
-					var webPath = "signup"
+					var webPath = "signup/clinician"
 
 					// if invitee is already a user (ie already has an account), he won't go to signup but login instead
 					if invite.UserId != "" {


### PR DESCRIPTION
Review the signup link so it is opening the __clinician__ signup page directly instead of signup page where one needs to choose type of account to be created.

I also bumped to 0.9.0 so we integrate fast.