### PR TITLE
Apply a new crowdin option to avoid the loss of translations

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,3 +1,4 @@
 files:
   - source: /templates/locales/en.yaml
     translation: /templates/locales/%two_letters_code%.yaml
+    update_option: update_as_unapproved


### PR DESCRIPTION
Translations are lost when we update the english (master) translation.
This new option is suposed to solve the problem