### PR TITLE
Feature/ylp 710 accept generic notifications bis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,12 @@
 Hydrophone is the module responsible for sending emails.
 This API sends notifications to users for things like forgotten passwords, initial signup, and invitations.
 
-## unreleased
+## 1.6.1 - 2021-05-04
+### Changed
+- YLP-710 Modify route /accept/team/invite to acknowledge notifications that does not requires a specific action (i.e. change member role)
 ### Fixed 
-- YLP-531 Reset key can be null on a reset password api call
+- YLP-531 Bug: Reset key can be null on a reset password api call
+
 ## 1.6.0 - 2021-04-28
 ### Changed
 - YLP-559 emails which are part of URLs are URL encoded

--- a/api/hydrophoneApi.go
+++ b/api/hydrophoneApi.go
@@ -156,10 +156,8 @@ func (a *Api) SetHandlers(prefix string, rtr *mux.Router) {
 	accept.Handle("/signup/{confirmationid}", varsHandler(a.acceptSignUp)).Methods("PUT")
 	accept.Handle("/forgot", varsHandler(a.acceptPassword)).Methods("PUT")
 	accept.Handle("/invite/{userid}/{invitedby}", varsHandler(a.AcceptInvite)).Methods("PUT")
-	// PUT /confirm/accept/invite
-	accept.Handle("/any/invite", varsHandler(a.AcceptAnyInvite)).Methods("PUT")
 	// PUT /confirm/accept/team/invite
-	accept.Handle("/team/invite/{userid}/{teamid}", varsHandler(a.AcceptTeamInvite)).Methods("PUT")
+	accept.Handle("/team/invite", varsHandler(a.AcceptTeamNotifs)).Methods("PUT")
 
 	// GET /confirm/signup/:userid
 	// GET /confirm/invite/:userid

--- a/api/hydrophoneApi.go
+++ b/api/hydrophoneApi.go
@@ -156,6 +156,8 @@ func (a *Api) SetHandlers(prefix string, rtr *mux.Router) {
 	accept.Handle("/signup/{confirmationid}", varsHandler(a.acceptSignUp)).Methods("PUT")
 	accept.Handle("/forgot", varsHandler(a.acceptPassword)).Methods("PUT")
 	accept.Handle("/invite/{userid}/{invitedby}", varsHandler(a.AcceptInvite)).Methods("PUT")
+	// PUT /confirm/accept/invite
+	accept.Handle("/any/invite", varsHandler(a.AcceptAnyInvite)).Methods("PUT")
 	// PUT /confirm/accept/team/invite
 	accept.Handle("/team/invite/{userid}/{teamid}", varsHandler(a.AcceptTeamInvite)).Methods("PUT")
 

--- a/api/hydrophoneApi_test.go
+++ b/api/hydrophoneApi_test.go
@@ -11,11 +11,11 @@ import (
 	"github.com/gorilla/mux"
 
 	crewClient "github.com/mdblp/crew/client"
-	commonClients "github.com/tidepool-org/go-common/clients"
-	"github.com/tidepool-org/go-common/clients/portal"
 	"github.com/mdblp/shoreline/clients/shoreline"
 	"github.com/mdblp/shoreline/schema"
 	"github.com/mdblp/shoreline/token"
+	commonClients "github.com/tidepool-org/go-common/clients"
+	"github.com/tidepool-org/go-common/clients/portal"
 	"github.com/tidepool-org/go-common/clients/version"
 	"github.com/tidepool-org/hydrophone/clients"
 	"github.com/tidepool-org/hydrophone/localize"
@@ -116,6 +116,7 @@ type (
 		desc          string
 		skip          bool
 		returnNone    bool
+		doBad         bool
 		method        string
 		url           string
 		body          testJSONObject

--- a/api/invite.go
+++ b/api/invite.go
@@ -1099,7 +1099,7 @@ func (a *Api) SendTeamInvite(res http.ResponseWriter, req *http.Request, vars ma
 }
 
 // @Summary Send notification to an hcp that becomes admin
-// @Description  Send an email and a notification to the new admin user. Removing the admin role does not trigger any notification or email.
+// @Description  Send an email and a notification to the new admin user. The role change is done but notification is pushed for information (notifacation status is set to pending). Removing the admin role is managed as an exception. It does not trigger any notification or email.
 // @ID hydrophone-api-UpdateTeamRole
 // @Accept  json
 // @Produce  json

--- a/api/invite.go
+++ b/api/invite.go
@@ -394,7 +394,7 @@ func (a *Api) AcceptInvite(res http.ResponseWriter, req *http.Request, vars map[
 // http.StatusForbidden when mismatch of user ID's, type or status
 // @Summary Accept the given invite
 // @Description  This would be PUT by the web page at the link in the invite email. No authentication is required.
-// @ID hydrophone-api-acceptAnyInvite
+// @ID hydrophone-api-acceptTeamNotifs
 // @Accept  json
 // @Produce  json
 // @Param invitation body models.Confirmation true "invitation details"
@@ -468,9 +468,7 @@ func (a *Api) AcceptTeamNotifs(res http.ResponseWriter, req *http.Request, vars 
 	}
 
 	switch conf.Type {
-	case models.TypeMedicalTeamPatientInvite:
-		a.acceptTeamInvite(res, req, conf)
-	case models.TypeMedicalTeamInvite:
+	case models.TypeMedicalTeamPatientInvite, models.TypeMedicalTeamInvite:
 		a.acceptTeamInvite(res, req, conf)
 	default:
 		a.acceptAnyInvite(res, req, conf)
@@ -1021,7 +1019,7 @@ func (a *Api) SendTeamInvite(res http.ResponseWriter, req *http.Request, vars ma
 }
 
 // @Summary Send notification to an hcp that becomes admin
-// @Description  Send an email and a notification to the new admin user. The role change is done but notification is pushed for information (notifacation status is set to pending). Removing the admin role is managed as an exception. It does not trigger any notification or email.
+// @Description  Send an email and a notification to the new admin user. The role change is done but notification is pushed for information (notification status is set to pending). Removing the admin role is managed as an exception. It does not trigger any notification or email.
 // @ID hydrophone-api-UpdateTeamRole
 // @Accept  json
 // @Produce  json

--- a/api/invite.go
+++ b/api/invite.go
@@ -404,9 +404,9 @@ func (a *Api) AcceptInvite(res http.ResponseWriter, req *http.Request, vars map[
 // @Failure 403 {object} status.Status "Operation is forbiden. The invitation cannot be accepted for this given user"
 // @Failure 404 {object} status.Status "invitation not found"
 // @Failure 500 {object} status.Status "Error (internal) while processing the data"
-// @Router /accept/any/invite [put]
+// @Router /accept/team/invite [put]
 // @security TidepoolAuth
-func (a *Api) AcceptAnyInvite(res http.ResponseWriter, req *http.Request, vars map[string]string) {
+func (a *Api) AcceptTeamNotifs(res http.ResponseWriter, req *http.Request, vars map[string]string) {
 	token := a.token(res, req)
 	if token == nil {
 		return
@@ -447,7 +447,12 @@ func (a *Api) AcceptAnyInvite(res http.ResponseWriter, req *http.Request, vars m
 	validationErrors := []error{}
 
 	conf.ValidateStatus(models.StatusPending, &validationErrors).
-		ValidateType([]models.Type{models.TypeMedicalTeamDoAdmin, models.TypeMedicalTeamRemove}, &validationErrors).
+		ValidateType([]models.Type{
+			models.TypeMedicalTeamDoAdmin,
+			models.TypeMedicalTeamRemove,
+			models.TypeMedicalTeamInvite,
+			models.TypeMedicalTeamPatientInvite,
+		}, &validationErrors).
 		ValidateUserID(inviteeID, &validationErrors)
 
 	if len(validationErrors) > 0 {
@@ -462,7 +467,20 @@ func (a *Api) AcceptAnyInvite(res http.ResponseWriter, req *http.Request, vars m
 		return
 	}
 
+	switch conf.Type {
+	case models.TypeMedicalTeamPatientInvite:
+		a.acceptTeamInvite(res, req, conf)
+	case models.TypeMedicalTeamInvite:
+		a.acceptTeamInvite(res, req, conf)
+	default:
+		a.acceptAnyInvite(res, req, conf)
+	}
+
 	log.Printf("AcceptInvite: permissions were set for [%v] after an invite was accepted", inviteeID)
+
+}
+
+func (a *Api) acceptAnyInvite(res http.ResponseWriter, req *http.Request, conf *models.Confirmation) {
 	conf.UpdateStatus(models.StatusCompleted)
 	if !a.addOrUpdateConfirmation(req.Context(), conf, res) {
 		statusErr := &status.StatusError{Status: status.NewStatus(http.StatusInternalServerError, STATUS_ERR_SAVING_CONFIRMATION)}
@@ -475,112 +493,16 @@ func (a *Api) AcceptAnyInvite(res http.ResponseWriter, req *http.Request, vars m
 	res.Write([]byte(STATUS_OK))
 }
 
-//Accept the team invite for a member
-//
-// http.StatusOK when accepted
-// http.StatusBadRequest when the incoming data is incomplete or incorrect
-// http.StatusForbidden when mismatch of user ID's, type or status
-// @Summary Accept the given invite
-// @Description  This would be PUT by the web page at the link in the invite email. No authentication is required.
-// @ID hydrophone-api-acceptTeamInvite
-// @Accept  json
-// @Produce  json
-// @Param userid path string true "invitee id"
-// @Param teamid path string true "team id"
-// @Param invitation body models.Confirmation true "invitation details"
-// @Success 200 {string} string "OK"
-// @Failure 400 {object} status.Status "inviteeid, invitorid or/and the payload is missing or malformed"
-// @Failure 401 {object} status.Status "Authorization token is missing or does not provided sufficient privileges"
-// @Failure 403 {object} status.Status "Operation is forbiden. Either the authorization token is invalid or this invite cannot be accepted"
-// @Failure 404 {object} status.Status "invitation not found"
-// @Failure 500 {object} status.Status "Error (internal) while processing the data"
-// @Router /accept/team/invite/{userid}/{teamid} [put]
-// @security TidepoolAuth
-func (a *Api) AcceptTeamInvite(res http.ResponseWriter, req *http.Request, vars map[string]string) {
-	token := a.token(res, req)
-	if token == nil {
-		return
-	}
-
-	userID := vars["userid"]
-	teamID := vars["teamid"]
-
-	if userID == "" || teamID == "" {
-		log.Printf("AcceptInvite inviteeID %s or teamID %s not set", userID, teamID)
-		res.WriteHeader(http.StatusBadRequest)
-		return
-	}
-	if token.UserId != userID {
-		a.sendModelAsResWithStatus(
-			res,
-			&status.StatusError{Status: status.NewStatus(http.StatusUnauthorized, STATUS_UNAUTHORIZED)},
-			http.StatusUnauthorized,
-		)
-		return
-	}
-
-	accept := &models.Confirmation{}
-	if err := json.NewDecoder(req.Body).Decode(accept); err != nil {
-		log.Printf("AcceptInvite error decoding invite data: %v\n", err)
-		a.sendModelAsResWithStatus(
-			res,
-			&status.StatusError{Status: status.NewStatus(http.StatusBadRequest, STATUS_ERR_DECODING_CONFIRMATION)},
-			http.StatusBadRequest,
-		)
-		return
-	}
-
-	if accept.Key == "" {
-		log.Println("AcceptInvite has no confirmation key set")
-		res.WriteHeader(http.StatusBadRequest)
-		return
-	}
-
-	conf, err := a.findExistingConfirmation(req.Context(), accept, res)
-	if err != nil {
-		log.Printf("AcceptInvite error while finding confirmation [%s]\n", err.Error())
-		a.sendModelAsResWithStatus(res, err, http.StatusInternalServerError)
-		return
-	}
-	if conf == nil {
-		statusErr := &status.StatusError{Status: status.NewStatus(http.StatusNotFound, statusInviteNotFoundMessage)}
-		log.Println("AcceptInvite ", statusErr.Error())
-		a.sendModelAsResWithStatus(res, statusErr, http.StatusNotFound)
-		return
-	}
-
-	validationErrors := []error{}
-
-	conf.ValidateStatus(models.StatusPending, &validationErrors).
-		ValidateUserID(userID, &validationErrors).
-		ValidateTeamID(teamID, &validationErrors)
-
-	if conf.Role != "patient" {
-		conf.ValidateType([]models.Type{models.TypeMedicalTeamInvite}, &validationErrors)
-	} else {
-		conf.ValidateType([]models.Type{models.TypeMedicalTeamPatientInvite}, &validationErrors)
-	}
-
-	if len(validationErrors) > 0 {
-		for _, validationError := range validationErrors {
-			log.Println("AcceptInvite forbidden as there was a expectation mismatch", validationError)
-		}
-		a.sendModelAsResWithStatus(
-			res,
-			&status.StatusError{Status: status.NewStatus(http.StatusForbidden, statusForbiddenMessage)},
-			http.StatusForbidden,
-		)
-		return
-	}
+func (a *Api) acceptTeamInvite(res http.ResponseWriter, req *http.Request, conf *models.Confirmation) {
 
 	var member = store.Member{
-		UserID:           userID,
-		TeamID:           teamID,
+		UserID:           conf.UserId,
+		TeamID:           conf.TeamID,
 		InvitationStatus: "accepted",
 		Role:             conf.Role,
 	}
 	// are we updating a team member or a patient
-	err = nil
+	var err error
 	if conf.Role != "patient" {
 		_, err = a.perms.UpdateTeamMember(req.Header.Get(TP_SESSION_TOKEN), member)
 	} else {
@@ -596,7 +518,7 @@ func (a *Api) AcceptTeamInvite(res http.ResponseWriter, req *http.Request, vars 
 		return
 	}
 
-	log.Printf("AcceptInvite: permissions were set for [%v -> %v] after an invite was accepted", teamID, userID)
+	log.Printf("AcceptInvite: permissions were set for [%v -> %v] after an invite was accepted", conf.TeamID, conf.UserId)
 	conf.UpdateStatus(models.StatusCompleted)
 	if !a.addOrUpdateConfirmation(req.Context(), conf, res) {
 		statusErr := &status.StatusError{Status: status.NewStatus(http.StatusInternalServerError, STATUS_ERR_SAVING_CONFIRMATION)}

--- a/api/invite_test.go
+++ b/api/invite_test.go
@@ -673,7 +673,7 @@ func TestInviteResponds(t *testing.T) {
 		{
 			desc:     "valid request to accept an team invite",
 			method:   http.MethodPut,
-			url:      fmt.Sprintf("/accept/team/invite/%s/%s", "123.456.789", "123456"),
+			url:      fmt.Sprintf("/accept/team/invite"),
 			token:    testing_token_uid1,
 			respCode: http.StatusOK,
 			body: testJSONObject{
@@ -683,7 +683,7 @@ func TestInviteResponds(t *testing.T) {
 		{
 			desc:     "valid request to accept an team invite for a patient",
 			method:   http.MethodPut,
-			url:      fmt.Sprintf("/accept/team/invite/%s/%s", "123.456.789", "123456"),
+			url:      fmt.Sprintf("/accept/team/invite"),
 			token:    testing_token_uid1,
 			respCode: http.StatusOK,
 			body: testJSONObject{
@@ -692,19 +692,19 @@ func TestInviteResponds(t *testing.T) {
 			},
 		},
 		{
-			desc:     "not authorized request to accept an team invite",
+			desc:     "not authorized request to accept a team invite",
 			method:   http.MethodPut,
-			url:      fmt.Sprintf("/accept/team/invite/%s/%s", "not.authorized", "123456"),
+			url:      fmt.Sprintf("/accept/team/invite"),
 			token:    testing_token_uid1,
-			respCode: http.StatusUnauthorized,
+			respCode: http.StatusForbidden,
 			body: testJSONObject{
-				"key": "medicalteam.invite.member",
+				"key": "medicalteam.invite.wrong.member",
 			},
 		},
 		{
 			desc:     "invitation does not exist",
 			method:   http.MethodPut,
-			url:      fmt.Sprintf("/accept/team/invite/%s/%s", "123.456.789", "123456"),
+			url:      fmt.Sprintf("/accept/team/invite"),
 			token:    testing_token_uid1,
 			respCode: http.StatusForbidden,
 			body: testJSONObject{
@@ -714,7 +714,7 @@ func TestInviteResponds(t *testing.T) {
 		{
 			desc:     "invalid invitation",
 			method:   http.MethodPut,
-			url:      fmt.Sprintf("/accept/team/invite/%s/%s", "123.456.789", "123456"),
+			url:      fmt.Sprintf("/accept/team/invite"),
 			token:    testing_token_uid1,
 			respCode: http.StatusNotFound,
 			body: testJSONObject{
@@ -724,14 +724,14 @@ func TestInviteResponds(t *testing.T) {
 		{
 			desc:     "Any invite no key",
 			method:   http.MethodPut,
-			url:      "/accept/any/invite",
+			url:      "/accept/team/invite",
 			token:    testing_token_uid1,
 			respCode: http.StatusBadRequest,
 		},
 		{
 			desc:   "Any invite invalid key",
 			method: http.MethodPut,
-			url:    "/accept/any/invite",
+			url:    "/accept/team/invite",
 			token:  testing_token_uid1,
 			body: testJSONObject{
 				"key": "any.invite.invalid.key",
@@ -741,7 +741,7 @@ func TestInviteResponds(t *testing.T) {
 		{
 			desc:   "Any invite already completed",
 			method: http.MethodPut,
-			url:    "/accept/any/invite",
+			url:    "/accept/team/invite",
 			token:  testing_token_uid1,
 			body: testJSONObject{
 				"key": "any.invite.completed.key",
@@ -752,7 +752,7 @@ func TestInviteResponds(t *testing.T) {
 			desc:   "Error getting invite",
 			doBad:  true,
 			method: http.MethodPut,
-			url:    "/accept/any/invite",
+			url:    "/accept/team/invite",
 			token:  testing_token_uid1,
 			body: testJSONObject{
 				"key": "foo",
@@ -762,17 +762,17 @@ func TestInviteResponds(t *testing.T) {
 		{
 			desc:   "Any invite not a valid type",
 			method: http.MethodPut,
-			url:    "/accept/any/invite",
+			url:    "/accept/team/invite",
 			token:  testing_token_uid1,
 			body: testJSONObject{
-				"key": "medicalteam.invite.patient",
+				"key": "invite.wrong.type",
 			},
 			respCode: http.StatusForbidden,
 		},
 		{
 			desc:   "Any valid invite do admin",
 			method: http.MethodPut,
-			url:    "/accept/any/invite",
+			url:    "/accept/team/invite",
 			token:  testing_token_uid1,
 			body: testJSONObject{
 				"key": "any.invite.pending.do.admin",
@@ -782,7 +782,7 @@ func TestInviteResponds(t *testing.T) {
 		{
 			desc:   "Any valid invite remove",
 			method: http.MethodPut,
-			url:    "/accept/any/invite",
+			url:    "/accept/team/invite",
 			token:  testing_token_uid1,
 			body: testJSONObject{
 				"key": "any.invite.pending.remove",

--- a/api/invite_test.go
+++ b/api/invite_test.go
@@ -721,6 +721,74 @@ func TestInviteResponds(t *testing.T) {
 				"key": "key.does.not.exist",
 			},
 		},
+		{
+			desc:     "Any invite no key",
+			method:   http.MethodPut,
+			url:      "/accept/any/invite",
+			token:    testing_token_uid1,
+			respCode: http.StatusBadRequest,
+		},
+		{
+			desc:   "Any invite invalid key",
+			method: http.MethodPut,
+			url:    "/accept/any/invite",
+			token:  testing_token_uid1,
+			body: testJSONObject{
+				"key": "any.invite.invalid.key",
+			},
+			respCode: http.StatusNotFound,
+		},
+		{
+			desc:   "Any invite already completed",
+			method: http.MethodPut,
+			url:    "/accept/any/invite",
+			token:  testing_token_uid1,
+			body: testJSONObject{
+				"key": "any.invite.completed.key",
+			},
+			respCode: http.StatusForbidden,
+		},
+		{
+			desc:   "Error getting invite",
+			doBad:  true,
+			method: http.MethodPut,
+			url:    "/accept/any/invite",
+			token:  testing_token_uid1,
+			body: testJSONObject{
+				"key": "foo",
+			},
+			respCode: http.StatusInternalServerError,
+		},
+		{
+			desc:   "Any invite not a valid type",
+			method: http.MethodPut,
+			url:    "/accept/any/invite",
+			token:  testing_token_uid1,
+			body: testJSONObject{
+				"key": "medicalteam.invite.patient",
+			},
+			respCode: http.StatusForbidden,
+		},
+		{
+			desc:   "Any valid invite do admin",
+			method: http.MethodPut,
+			url:    "/accept/any/invite",
+			token:  testing_token_uid1,
+			body: testJSONObject{
+				"key": "any.invite.pending.do.admin",
+			},
+			respCode: http.StatusOK,
+		},
+		{
+			desc:   "Any valid invite remove",
+			method: http.MethodPut,
+			url:    "/accept/any/invite",
+			token:  testing_token_uid1,
+			body: testJSONObject{
+				"key": "any.invite.pending.remove",
+			},
+			respCode: http.StatusOK,
+		},
 	}
 
 	templatesPath, found := os.LookupEnv("TEMPLATE_PATH")
@@ -767,6 +835,19 @@ func TestInviteResponds(t *testing.T) {
 			hydrophone = InitApi(
 				FAKE_CONFIG,
 				mockStoreEmpty,
+				mockNotifier,
+				mockShoreline,
+				mockPerms,
+				mockSeagull,
+				mockPortal,
+				mockTemplates,
+			)
+		}
+		// testing when returning errors
+		if inviteTest.doBad {
+			hydrophone = InitApi(
+				FAKE_CONFIG,
+				mockStoreFails,
 				mockNotifier,
 				mockShoreline,
 				mockPerms,

--- a/api/invite_test.go
+++ b/api/invite_test.go
@@ -673,7 +673,7 @@ func TestInviteResponds(t *testing.T) {
 		{
 			desc:     "valid request to accept an team invite",
 			method:   http.MethodPut,
-			url:      fmt.Sprintf("/accept/team/invite"),
+			url:      "/accept/team/invite",
 			token:    testing_token_uid1,
 			respCode: http.StatusOK,
 			body: testJSONObject{
@@ -683,7 +683,7 @@ func TestInviteResponds(t *testing.T) {
 		{
 			desc:     "valid request to accept an team invite for a patient",
 			method:   http.MethodPut,
-			url:      fmt.Sprintf("/accept/team/invite"),
+			url:      "/accept/team/invite",
 			token:    testing_token_uid1,
 			respCode: http.StatusOK,
 			body: testJSONObject{
@@ -694,7 +694,7 @@ func TestInviteResponds(t *testing.T) {
 		{
 			desc:     "not authorized request to accept a team invite",
 			method:   http.MethodPut,
-			url:      fmt.Sprintf("/accept/team/invite"),
+			url:      "/accept/team/invite",
 			token:    testing_token_uid1,
 			respCode: http.StatusForbidden,
 			body: testJSONObject{
@@ -704,7 +704,7 @@ func TestInviteResponds(t *testing.T) {
 		{
 			desc:     "invitation does not exist",
 			method:   http.MethodPut,
-			url:      fmt.Sprintf("/accept/team/invite"),
+			url:      "/accept/team/invite",
 			token:    testing_token_uid1,
 			respCode: http.StatusForbidden,
 			body: testJSONObject{
@@ -714,7 +714,7 @@ func TestInviteResponds(t *testing.T) {
 		{
 			desc:     "invalid invitation",
 			method:   http.MethodPut,
-			url:      fmt.Sprintf("/accept/team/invite"),
+			url:      "/accept/team/invite",
 			token:    testing_token_uid1,
 			respCode: http.StatusNotFound,
 			body: testJSONObject{

--- a/clients/mockStoreClient.go
+++ b/clients/mockStoreClient.go
@@ -85,11 +85,23 @@ func (d *MockStoreClient) FindConfirmation(ctx context.Context, notification *mo
 	if notification.Key == "key.to.be.dismissed" {
 		notification.Status = "pending"
 	}
+	if notification.Key == "invite.wrong.type" {
+		notification.Status = "pending"
+		notification.Type = "a.wrong.type"
+		notification.TeamID = "123456"
+		notification.UserId = "123.456.789"
+	}
 	if notification.Key == "medicalteam.invite.member" {
 		notification.Status = "pending"
 		notification.Type = "medicalteam_invitation"
 		notification.TeamID = "123456"
 		notification.UserId = "123.456.789"
+	}
+	if notification.Key == "medicalteam.invite.wrong.member" {
+		notification.Status = "pending"
+		notification.Type = "medicalteam_invitation"
+		notification.TeamID = "123456"
+		notification.UserId = "not.my.id"
 	}
 	if notification.Key == "medicalteam.invite.patient" {
 		notification.Status = "pending"

--- a/clients/mockStoreClient.go
+++ b/clients/mockStoreClient.go
@@ -106,6 +106,22 @@ func (d *MockStoreClient) FindConfirmation(ctx context.Context, notification *mo
 	if notification.Key == "key.does.not.exist" {
 		return nil, nil
 	}
+	if notification.Key == "any.invite.invalid.key" {
+		return nil, nil
+	}
+	if notification.Key == "any.invite.completed.key" {
+		notification.Status = "completed"
+	}
+	if notification.Key == "any.invite.pending.do.admin" {
+		notification.Status = "pending"
+		notification.Type = "medicalteam_do_admin"
+		notification.UserId = "123.456.789"
+	}
+	if notification.Key == "any.invite.pending.remove" {
+		notification.Status = "pending"
+		notification.Type = "medicalteam_remove"
+		notification.UserId = "123.456.789"
+	}
 	return notification, nil
 }
 

--- a/models/confirmation.go
+++ b/models/confirmation.go
@@ -203,13 +203,18 @@ func (c *Confirmation) ValidateStatus(expectedStatus Status, validationErrors *[
 	return c
 }
 
-func (c *Confirmation) ValidateType(expectedType Type, validationErrors *[]error) *Confirmation {
-	if expectedType != c.Type {
-		*validationErrors = append(
-			*validationErrors,
-			fmt.Errorf("Confirmation expected Type `%s` but had `%s`", expectedType, c.Type),
-		)
+func (c *Confirmation) ValidateType(expectedTypes []Type, validationErrors *[]error) *Confirmation {
+	types := ""
+	for _, expectedType := range expectedTypes {
+		if expectedType == c.Type {
+			return c
+		}
+		types = fmt.Sprintf("%s, %s", types, expectedType)
 	}
+	*validationErrors = append(
+		*validationErrors,
+		fmt.Errorf("Confirmation expected Type(s) `%s` but had `%s`", types, c.Type),
+	)
 	return c
 }
 

--- a/models/confirmation.go
+++ b/models/confirmation.go
@@ -183,16 +183,6 @@ func (c *Confirmation) ValidateUserID(expectedUserID string, validationErrors *[
 	return c
 }
 
-func (c *Confirmation) ValidateTeamID(expectedTeamID string, validationErrors *[]error) *Confirmation {
-	if expectedTeamID != c.TeamID {
-		*validationErrors = append(
-			*validationErrors,
-			fmt.Errorf("Confirmation expected TeamId of `%s` but had `%s`", expectedTeamID, c.TeamID),
-		)
-	}
-	return c
-}
-
 func (c *Confirmation) ValidateStatus(expectedStatus Status, validationErrors *[]error) *Confirmation {
 	if expectedStatus != c.Status {
 		*validationErrors = append(


### PR DESCRIPTION
Merge accept invite routes for teams. No need to have 2 dinstinct routes

* userID is already provided in the token, not need to provide it in the url
* teamId is already part of the confirm record (in the db)