### PR TITLE
YLP-708 A HCP user shouldn't invite a patient to join a team

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 Hydrophone is the module responsible for sending emails.
 This API sends notifications to users for things like forgotten passwords, initial signup, and invitations.
 
+## unreleased 
+# Fixed
+- YLP-708 A HCP user shouldn't invite a patient to join a team 
 ## 1.6.1 - 2021-05-04
 ### Changed
 - YLP-710 Modify route /accept/team/invite to acknowledge notifications that does not requires a specific action (i.e. change member role)

--- a/api/hydrophoneApi_test.go
+++ b/api/hydrophoneApi_test.go
@@ -98,7 +98,7 @@ func (m *testingShorelingMock) GetUser(userID, token string) (*schema.UserData, 
 		return &schema.UserData{UserID: testing_uid3, Emails: []string{userID}, Username: userID}, nil
 	}
 	if userID == "patient.team@myemail.com" {
-		return &schema.UserData{UserID: testing_uid4, Emails: []string{userID}, Username: userID}, nil
+		return &schema.UserData{UserID: testing_uid4, Emails: []string{userID}, Username: userID, Roles: []string{"patient"}}, nil
 	}
 
 	return &schema.UserData{UserID: m.userid, Emails: []string{m.userid + "@email.org"}, Username: m.userid + "@email.org"}, nil

--- a/api/invite.go
+++ b/api/invite.go
@@ -878,6 +878,7 @@ func (a *Api) SendInvite(res http.ResponseWriter, req *http.Request, vars map[st
 // @Failure 400 {object} status.Status "userId, teamId and isAdmin were not provided or the payload is missing/malformed"
 // @Failure 401 {object} status.Status "Authorization token is missing or does not provide sufficient privileges"
 // @Failure 403 {object} status.Status "Authorization token is invalid"
+// @Failure 405 {object} status.Status "HCP cannot invite a patient to care team"
 // @Failure 409 {object} status.Status "user already has a pending or declined invite OR user is already part of the team"
 // @Failure 422 {object} status.Status "Error when sending the email (probably caused by the mailling service"
 // @Failure 500 {object} status.Status "Internal error while processing the invite, detailled error returned in the body"
@@ -964,6 +965,12 @@ func (a *Api) SendTeamInvite(res http.ResponseWriter, req *http.Request, vars ma
 			invite.UserId = invitedUsr.UserID
 			member.UserID = invitedUsr.UserID
 			inviteeLanguage = a.getUserLanguage(invite.UserId, res)
+		}
+		// patient cannot be invited as a member of a care team
+		if invitedUsr.HasRole("patient") && !managePatients {
+			statusErr := &status.StatusError{Status: status.NewStatus(http.StatusMethodNotAllowed, STATUS_PATIENT_NOT_AUTH)}
+			a.sendModelAsResWithStatus(res, statusErr, statusErr.Code)
+			return
 		}
 		err := error(nil)
 		if !managePatients {

--- a/api/invite_test.go
+++ b/api/invite_test.go
@@ -94,6 +94,12 @@ func initTestingTeamRouter(returnNone bool) *mux.Router {
 		Members:     membersAddAdminRole,
 		ID:          "teamDeleteMember",
 	}
+	teamAddPatientAsMember := store.Team{
+		Name:        "team add a patient as a member",
+		Description: "Fake Team",
+		Members:     members,
+		ID:          "teamInvitePatient",
+	}
 	membersDismissInvite := []store.Member{
 		{
 			UserID:           testing_uid3,
@@ -156,6 +162,7 @@ func initTestingTeamRouter(returnNone bool) *mux.Router {
 	mockPerms.SetMockNextCall(testing_token_uid1+testing_uid3, &member_uid3, nil)
 	mockPerms.SetMockNextCall(testing_token_uid1+"teamAddAdminRole", &teamAddAdminRole, nil)
 	mockPerms.SetMockNextCall(testing_token_uid1+"teamAlreadyMember", &teamAlreadyMember, nil)
+	mockPerms.SetMockNextCall(testing_token_uid1+"teamInvitePatient", &teamAddPatientAsMember, nil)
 	mockPerms.SetMockNextCall(testing_token_uid1+"teamDeleteMember", &teamDeleteMember, nil)
 	mockPerms.SetMockNextCall(testing_token_uid1+testing_uid1, &membersDismissInvite_uid1, nil)
 	mockPerms.SetMockNextCall(testing_token_uid1+"teamDismissInvite", &teamDismissInvite, nil)
@@ -229,6 +236,18 @@ func initTests() []toTest {
 			body: testJSONObject{
 				"email":  "me2@myemail.com",
 				"teamId": "teamAlreadyMember",
+			},
+		},
+		// returns a 405 when the invited member is a patient
+		{
+			method:     "POST",
+			url:        "/send/team/invite",
+			returnNone: true,
+			respCode:   405,
+			token:      testing_token_uid1,
+			body: testJSONObject{
+				"email":  "patient.team@myemail.com",
+				"teamId": "teamInvitePatient",
 			},
 		},
 		// returns a 200 when everything goes well to add an admin role

--- a/api/signup.go
+++ b/api/signup.go
@@ -30,6 +30,7 @@ const (
 	STATUS_MISSING_BIRTHDAY  = "Birthday is missing"
 	STATUS_INVALID_BIRTHDAY  = "Birthday specified is invalid"
 	STATUS_MISMATCH_BIRTHDAY = "Birthday specified does not match patient birthday"
+	STATUS_PATIENT_NOT_AUTH  = "Patient cannot be member of care team"
 )
 
 const (


### PR DESCRIPTION
hydrophone will return a `405` (method not allowed) with the following message: `Patient cannot be member of care team`