### PR TITLE
YLP-770 BUcket of team invite bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 Hydrophone is the module responsible for sending emails.
 This API sends notifications to users for things like forgotten passwords, initial signup, and invitations.
 
+## 1.6.4 - 2021-05-20
+### Fixed
+- It is not allowed to send multiple team invite to the same patient (duplicates)
+
+### Added
+- New generic route to cancel invites (caregiver and team invites)
+
 ## 1.6.3
 ### Fixed 
 - Encoded emails are missing in email templates.

--- a/api/hydrophoneApi.go
+++ b/api/hydrophoneApi.go
@@ -15,7 +15,6 @@ import (
 	"github.com/nicksnyder/go-i18n/v2/i18n"
 
 	crewClient "github.com/mdblp/crew/client"
-	"github.com/mdblp/crew/store"
 	"github.com/mdblp/shoreline/clients/shoreline"
 	"github.com/mdblp/shoreline/schema"
 	"github.com/mdblp/shoreline/token"
@@ -180,6 +179,7 @@ func (a *Api) SetHandlers(prefix string, rtr *mux.Router) {
 
 	// PUT /confirm/:userid/invited/:invited_address
 	// PUT /confirm/signup/:userid
+	//rtr.Handle("/cancel/team/invite", varsHandler(a.CancelAnyInvite)).Methods("POST")
 	rtr.Handle("/{userid}/invited/{invited_address}", varsHandler(a.CancelInvite)).Methods("PUT")
 	rtr.Handle("/signup/{userid}", varsHandler(a.cancelSignUp)).Methods("PUT")
 }
@@ -487,32 +487,4 @@ func (a *Api) isAuthorizedUser(tokenData *token.TokenData, userId string) bool {
 	} else {
 		return false
 	}
-}
-
-// userId is member of a Team
-// Settings the all parameter to true will return all the members while it will only return the accepted members if the parameter is set false
-func (a *Api) isTeamMember(userID string, team store.Team, all bool) bool {
-	for i := 0; i < len(team.Members); i++ {
-		if team.Members[i].UserID == userID && (team.Members[i].InvitationStatus == "accepted" || all) {
-			return true
-		}
-	}
-	return false
-}
-
-//
-// return true is the user userID is admin of the Team identified by teamID
-// it returns the Team object corresponding to the team
-// if any error occurs during the search, it returns an error with the
-// related code
-func (a *Api) getTeamForUser(token, teamID, userID string, res http.ResponseWriter) (bool, store.Team, error) {
-	var auth = false
-	team, err := a.perms.GetTeam(token, teamID)
-	if err != nil {
-		statusErr := &status.StatusError{Status: status.NewStatus(http.StatusBadRequest, STATUS_ERR_FINDING_TEAM)}
-		a.sendModelAsResWithStatus(res, statusErr, statusErr.Code)
-		return auth, store.Team{}, err
-	}
-	auth = a.isTeamAdmin(userID, *team)
-	return auth, *team, nil
 }

--- a/api/hydrophoneApi.go
+++ b/api/hydrophoneApi.go
@@ -176,10 +176,10 @@ func (a *Api) SetHandlers(prefix string, rtr *mux.Router) {
 		varsHandler(a.dismissSignUp)).Methods("PUT")
 	// PUT /confirm/dismiss/team/invite/{teamid}
 	dismiss.Handle("/team/invite/{teamid}", varsHandler(a.DismissTeamInvite)).Methods("PUT")
+	rtr.Handle("/cancel/invite", varsHandler(a.CancelAnyInvite)).Methods("POST")
 
 	// PUT /confirm/:userid/invited/:invited_address
 	// PUT /confirm/signup/:userid
-	//rtr.Handle("/cancel/team/invite", varsHandler(a.CancelAnyInvite)).Methods("POST")
 	rtr.Handle("/{userid}/invited/{invited_address}", varsHandler(a.CancelInvite)).Methods("PUT")
 	rtr.Handle("/signup/{userid}", varsHandler(a.cancelSignUp)).Methods("PUT")
 }

--- a/api/invite.go
+++ b/api/invite.go
@@ -264,7 +264,7 @@ func (a *Api) GetSentInvitations(res http.ResponseWriter, req *http.Request, var
 	found, err := a.Store.FindConfirmations(
 		req.Context(),
 		&models.Confirmation{CreatorId: invitorID, Type: models.TypeCareteamInvite},
-		[]models.Status{models.StatusPending, models.StatusDeclined},
+		[]models.Status{models.StatusPending},
 		[]models.Type{models.TypeCareteamInvite, models.TypeMedicalTeamInvite, models.TypeMedicalTeamPatientInvite},
 	)
 	if invitations := a.checkFoundConfirmations(tokenValue, res, found, err); invitations != nil {

--- a/api/invite.go
+++ b/api/invite.go
@@ -127,7 +127,7 @@ func (a *Api) checkForDuplicateTeamInvite(ctx context.Context, inviteeEmail, inv
 			return true, invitedUsr
 		}
 		for i := 0; i < len(members); i++ {
-			if members[i].UserID == invitedUsr.UserID {
+			if members[i].UserID == invitedUsr.UserID && members[i].InvitationStatus != "rejected" {
 				statusErr := &status.StatusError{Status: status.NewStatus(http.StatusConflict, statusExistingMemberMessage)}
 				a.sendModelAsResWithStatus(res, statusErr, http.StatusConflict)
 				return true, invitedUsr

--- a/api/invite.go
+++ b/api/invite.go
@@ -780,6 +780,19 @@ func (a *Api) DismissTeamInvite(res http.ResponseWriter, req *http.Request, vars
 	a.sendModelAsResWithStatus(res, statusErr, http.StatusNotFound)
 }
 
+// @Summary Cancel an invite
+// @Description Admin can cancel a team invite sent to an HCP. A member can cancel an invite sent to a patient. A patient can cancel an invite sent to a caregiver
+// @ID hydrophone-api-cancelAnyInvite
+// @Accept  json
+// @Produce  json
+// @Success 200 {string} string "OK"
+// @Failure 400 {object} status.Status "payload is missing or malformed"
+// @Failure 401 {object} status.Status "Authorization token is missing or does not provide sufficient privileges"
+// @Failure 403 {object} status.Status "Authorization token is invalid"
+// @Failure 404 {object} status.Status "invitation not found"
+// @Failure 500 {object} status.Status "Error (internal) while processing the data"
+// @Router /cancel/invite [post]
+// @security TidepoolAuth
 func (a *Api) CancelAnyInvite(res http.ResponseWriter, req *http.Request, vars map[string]string) {
 	token := a.token(res, req)
 	if token == nil {
@@ -845,7 +858,7 @@ func (a *Api) CancelAnyInvite(res http.ResponseWriter, req *http.Request, vars m
 		conf.UpdateStatus(models.StatusDeclined)
 
 		if a.addOrUpdateConfirmation(req.Context(), conf, res) {
-			log.Printf("cancel invite [%s] for [%s]", cancel.Key, cancel.Email)
+			log.Printf("cancel invite [%s]", cancel.Key)
 			a.logAudit(req, "cancelInvite ")
 			res.WriteHeader(http.StatusOK)
 			return

--- a/api/invite_test.go
+++ b/api/invite_test.go
@@ -162,6 +162,13 @@ func initTestingTeamRouter(returnNone bool) *mux.Router {
 		InvitationStatus: "pending",
 	}
 
+	member_dup := store.Member{
+		UserID:           testing_uid4,
+		TeamID:           "teamAlreadyMember",
+		Role:             "patient",
+		InvitationStatus: "pending",
+	}
+
 	member_dismissed := store.Member{
 		UserID:           testing_uid4,
 		TeamID:           "123456",
@@ -181,6 +188,9 @@ func initTestingTeamRouter(returnNone bool) *mux.Router {
 	mockPerms.SetMockNextCall(testing_token_uid1+testing_uid3, &member_uid3, nil)
 	mockPerms.SetMockNextCall(testing_token_uid1+"teamAddAdminRole", &teamAddAdminRole, nil)
 	mockPerms.SetMockNextCall(testing_token_uid1+"teamAlreadyMember", &teamAlreadyMember, nil)
+	mockPerms.SetMockNextCall("GetTeamPatients"+testing_token_uid1+"teamAlreadyMember", []store.Member{member_dup}, nil)
+	mockPerms.SetMockNextCall("GetTeamPatients"+testing_token_uid1+"teamInvitePatient", []store.Member{}, nil)
+	mockPerms.SetMockNextCall("GetTeamPatients"+testing_token_uid1+"123456", []store.Member{}, nil)
 	mockPerms.SetMockNextCall(testing_token_uid1+"teamInvitePatient", &teamAddPatientAsMember, nil)
 	mockPerms.SetMockNextCall(testing_token_uid1+"teamDeleteMember", &teamDeleteMember, nil)
 	mockPerms.SetMockNextCall(testing_token_uid1+testing_uid1, &membersDismissInvite_uid1, nil)

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751
 	github.com/aws/aws-sdk-go v1.34.24
 	github.com/gorilla/mux v1.8.0
-	github.com/mdblp/crew v0.2.1-0.20210519164127-29a9da20595d
+	github.com/mdblp/crew v0.2.1-0.20210520130101-e923243fc406
 	// Retrieved through go get github.com/mdblp/shoreline/clients/shoreline@dblp.1.5.1
 	github.com/mdblp/shoreline v0.14.2-0.20210503074837-5c41e0d08861
 	github.com/nicksnyder/go-i18n/v2 v2.0.3

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751
 	github.com/aws/aws-sdk-go v1.34.24
 	github.com/gorilla/mux v1.8.0
-	github.com/mdblp/crew v0.2.1-0.20210413074601-a0518c3b3ebf
+	github.com/mdblp/crew v0.2.1-0.20210519164127-29a9da20595d
 	// Retrieved through go get github.com/mdblp/shoreline/clients/shoreline@dblp.1.5.1
 	github.com/mdblp/shoreline v0.14.2-0.20210503074837-5c41e0d08861
 	github.com/nicksnyder/go-i18n/v2 v2.0.3

--- a/go.sum
+++ b/go.sum
@@ -155,6 +155,10 @@ github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Ky
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/mdblp/crew v0.2.1-0.20210413074601-a0518c3b3ebf h1:CvxQG6oXItzFecKrZZmiy0ErJ2GvYzlrQyazPollM4o=
 github.com/mdblp/crew v0.2.1-0.20210413074601-a0518c3b3ebf/go.mod h1:Q7F8ZLcx6V5/0ZBNlCGX1fHOritHUf16P1kib0A1UCU=
+github.com/mdblp/crew v0.2.1-0.20210519152427-dc9844d2e998 h1:avcNk6OPVldVWirL4gmJx+S7q0DX3drOuN0ZIxrCtpM=
+github.com/mdblp/crew v0.2.1-0.20210519152427-dc9844d2e998/go.mod h1:Q7F8ZLcx6V5/0ZBNlCGX1fHOritHUf16P1kib0A1UCU=
+github.com/mdblp/crew v0.2.1-0.20210519164127-29a9da20595d h1:rf1b7s1XpYu4HLUFr5g1FmtZbzo4xAZoE0EMBLS4f70=
+github.com/mdblp/crew v0.2.1-0.20210519164127-29a9da20595d/go.mod h1:Q7F8ZLcx6V5/0ZBNlCGX1fHOritHUf16P1kib0A1UCU=
 github.com/mdblp/go-common v0.7.2-0.20210323141933-6b225f5dacf1 h1:fVMLmm4A/uFQ6xQjd9vpRiXBzOqcgFOQuUhCVgQJWVw=
 github.com/mdblp/go-common v0.7.2-0.20210323141933-6b225f5dacf1/go.mod h1:cFFwPnC4pEjrr1YUwjyTfL8ogUgwuvjKe8+eS0bm9oA=
 github.com/mdblp/shoreline v0.14.2-0.20210330081142-417f8c014a42 h1:EU/k1g4MKQ2O+AOCCzxeLlM2of2bnukp6eWwoqkZ+oM=
@@ -163,9 +167,11 @@ github.com/mdblp/shoreline v0.14.2-0.20210503074837-5c41e0d08861 h1:kBojRIsHZU2M
 github.com/mdblp/shoreline v0.14.2-0.20210503074837-5c41e0d08861/go.mod h1:R6FWve5zivjue7E2nHqATc+bfsQDISbdaLVB0oS2suE=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421 h1:ZqeYNhU3OHLH3mGKHDcjJRFFRrJa6eAM5H+CtDdOsPc=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
+github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742 h1:Esafd1046DLDQ0W1YjYsBW+p8U2u7vzgW2SQVmlNazg=
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
+github.com/modern-go/reflect2 v1.0.1 h1:9f412s+6RmYXLWZSEzVVgPGK7C2PphHj5RJrvfx9AWI=
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/montanaflynn/stats v0.0.0-20171201202039-1bf9dbcd8cbe/go.mod h1:wL8QJuTMNUDYhXwkmfOly8iTdp5TEcJFWZD2D7SIkUc=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=

--- a/go.sum
+++ b/go.sum
@@ -159,6 +159,8 @@ github.com/mdblp/crew v0.2.1-0.20210519152427-dc9844d2e998 h1:avcNk6OPVldVWirL4g
 github.com/mdblp/crew v0.2.1-0.20210519152427-dc9844d2e998/go.mod h1:Q7F8ZLcx6V5/0ZBNlCGX1fHOritHUf16P1kib0A1UCU=
 github.com/mdblp/crew v0.2.1-0.20210519164127-29a9da20595d h1:rf1b7s1XpYu4HLUFr5g1FmtZbzo4xAZoE0EMBLS4f70=
 github.com/mdblp/crew v0.2.1-0.20210519164127-29a9da20595d/go.mod h1:Q7F8ZLcx6V5/0ZBNlCGX1fHOritHUf16P1kib0A1UCU=
+github.com/mdblp/crew v0.2.1-0.20210520130101-e923243fc406 h1:fiK+dORky4ieFuHAOp5ua17XQfM7xy0O+McomTEYzyU=
+github.com/mdblp/crew v0.2.1-0.20210520130101-e923243fc406/go.mod h1:Q7F8ZLcx6V5/0ZBNlCGX1fHOritHUf16P1kib0A1UCU=
 github.com/mdblp/go-common v0.7.2-0.20210323141933-6b225f5dacf1 h1:fVMLmm4A/uFQ6xQjd9vpRiXBzOqcgFOQuUhCVgQJWVw=
 github.com/mdblp/go-common v0.7.2-0.20210323141933-6b225f5dacf1/go.mod h1:cFFwPnC4pEjrr1YUwjyTfL8ogUgwuvjKe8+eS0bm9oA=
 github.com/mdblp/shoreline v0.14.2-0.20210330081142-417f8c014a42 h1:EU/k1g4MKQ2O+AOCCzxeLlM2of2bnukp6eWwoqkZ+oM=

--- a/models/confirmation.go
+++ b/models/confirmation.go
@@ -88,11 +88,12 @@ const (
 
 var (
 	Timeouts TypeDurations = TypeDurations{
-		TypeCareteamInvite:       7 * 24 * time.Hour,
-		TypePasswordReset:        7 * 24 * time.Hour,
-		TypeSignUp:               31 * 24 * time.Hour,
-		TypePatientPasswordReset: 1 * time.Hour,
-		TypeMedicalTeamInvite:    7 * 24 * time.Hour,
+		TypeCareteamInvite:           7 * 24 * time.Hour,
+		TypePasswordReset:            7 * 24 * time.Hour,
+		TypeSignUp:                   31 * 24 * time.Hour,
+		TypePatientPasswordReset:     1 * time.Hour,
+		TypeMedicalTeamInvite:        7 * 24 * time.Hour,
+		TypeMedicalTeamPatientInvite: 7 * 24 * time.Hour,
 	}
 )
 

--- a/models/confirmation.go
+++ b/models/confirmation.go
@@ -23,7 +23,7 @@ type (
 		UserId       string       `json:"-" bson:"userId"`
 		Team         *Team        `json:"target" bson:",inline"`
 		Role         string       `json:"role" bson:"role"`
-		Status       Status       `json:"-" bson:"status"`
+		Status       Status       `json:"status" bson:"status"`
 		Modified     time.Time    `json:"-" bson:"modified"`
 		ShortKey     string       `json:"shortKey" bson:"shortKey"`
 	}


### PR DESCRIPTION
* Forbid duplicate invites: it should not be possible to send team invites to users if they are already part of the team (status pending or accepted)
* Create a new route to cancel invites of any type (team + direct share)

Requires the latest version of CREW client