### PR TITLE
YLP-909

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 Hydrophone is the module responsible for sending emails.
 This API sends notifications to users for things like forgotten passwords, initial signup, and invitations.
 
+## 1.7.3 - 2021-10-19
+### Fixed
+- YLP-909: adapt confirmation record creations to work with the new version of Crew
+
 ## 1.7.2
 ### Fixed
 - YLP-975: support email link is not correctly rendered on email "patient password info"

--- a/api/hydrophoneApi.go
+++ b/api/hydrophoneApi.go
@@ -270,14 +270,6 @@ func (a *Api) checkFoundConfirmations(token string, res http.ResponseWriter, res
 				//report and move on
 				log.Println("Error getting profile", err.Error())
 			}
-			if results[i].Team != nil && results[i].Team.ID != "" {
-				team, err := a.perms.GetTeam(token, results[i].Team.ID)
-				if err != nil {
-					log.Println("Error getting team", err.Error())
-				} else {
-					results[i].Team.Name = team.Name
-				}
-			}
 		}
 		return results
 	}

--- a/api/invite.go
+++ b/api/invite.go
@@ -1070,7 +1070,7 @@ func (a *Api) SendInvite(res http.ResponseWriter, req *http.Request, vars map[st
 // @Router /confirm/send/team/invite [post]
 // @security TidepoolAuth
 func (a *Api) SendTeamInvite(res http.ResponseWriter, req *http.Request, vars map[string]string) {
-	// By default, the invitee language will be "en" for Englih (as we don't know which language suits him)
+	// By default, the invitee language will be "en" for English (as we don't know which language suits him)
 	// In case the invitee is a known user, the language will be overriden in a later step
 	var inviteeLanguage = GetUserChosenLanguage(req)
 	tokenValue := req.Header.Get(TP_SESSION_TOKEN)
@@ -1152,7 +1152,7 @@ func (a *Api) SendTeamInvite(res http.ResponseWriter, req *http.Request, vars ma
 				invitorID)
 		}
 		// complete invite
-		invite.Team = &models.Team{ID: ib.TeamID}
+		invite.Team = &models.Team{ID: ib.TeamID, Name: team.Name}
 		invite.Email = ib.Email
 		invite.Role = ib.Role
 		if invitedUsr != nil {
@@ -1330,6 +1330,7 @@ func (a *Api) UpdateTeamRole(res http.ResponseWriter, req *http.Request, vars ma
 
 		// if the invitee is already a user, we can use his preferences
 		invite.Team.ID = ib.TeamID
+		invite.Team.Name = team.Name
 		invite.Email = ib.Email
 		invite.Role = ib.Role
 		invite.Status = models.StatusPending
@@ -1442,6 +1443,7 @@ func (a *Api) DeleteTeamMember(res http.ResponseWriter, req *http.Request, vars 
 
 	// let's use the user preferences
 	invite.Team.ID = ib.TeamID
+	invite.Team.Name = team.Name
 	invite.Email = ib.Email
 	invite.Role = ib.Role
 	invite.UserId = inviteeID

--- a/models/confirmation.go
+++ b/models/confirmation.go
@@ -30,7 +30,7 @@ type (
 
 	Team struct {
 		ID   string `json:"id" bson:"teamId"`
-		Name string `json:"name" bson:"-"`
+		Name string `json:"name" bson:"teamName"`
 	}
 	//basic details for the creator of the confirmation
 	Creator struct {


### PR DESCRIPTION
Now that crew limits the access to the route /teams/:teamid for members only, we need to save the team info in the DB on the creation step.