### PR TITLE
Manage simple text in emails

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,7 +9,7 @@
             "program": "${workspaceRoot}",
             "env": {
                 "TIDEPOOL_HYDROPHONE_ENV": "{ \"portal\": { \"serviceSpec\": { \"type\": \"static\", \"hosts\": [\"http://api-private:3000\"] } }, \"hakken\": { \"host\": \"fake-hakken\", \"skipHakken\":true } }",
-                "TIDEPOOL_HYDROPHONE_SERVICE": "{ \"service\": { \"service\": \"hydrophone\", \"protocol\": \"http\", \"host\": \"localhost:9157\", \"keyFile\": \"config/key.pem\", \"certFile\": \"config/cert.pem\" }, \"hydrophone\" : { \"webUrl\": \"http://localhost:3000\", \"supportUrl\": \"mailto:<<email_to_support>>\", \"assetUrl\": \"<<url_to_s3_for_images>>\", \"i18nTemplatesPath\": \"./templates\", \"allowPatientResetPassword\": false, \"patientPasswordResetUrl\": \"https://xxxx\" }, \"notifierType\": \"null\" }",
+                "TIDEPOOL_HYDROPHONE_SERVICE": "{ \"service\": { \"service\": \"hydrophone\", \"protocol\": \"http\", \"host\": \"localhost:9157\", \"keyFile\": \"config/key.pem\", \"certFile\": \"config/cert.pem\" }, \"hydrophone\" : { \"webUrl\": \"http://localhost:3000\", \"supportUrl\": \"mailto:<<email_to_support>>\", \"assetUrl\": \"<<url_to_s3_for_images>>\", \"i18nTemplatesPath\": \"./templates\", \"allowPatientResetPassword\": false, \"patientPasswordResetUrl\": \"https://xxxx\" }, \"sesEmail\": { \"fromAddress\": \"test@diabeloop.fr\",\"serverEndpoint\": \"http://api-private:3000/mockserver\", \"configurationSet\": \"\",\"defaultTags\": {\"environment\": \"local\", \"service\": \"hydrophone\"}} }",
                 "SERVICE_NAME": "hydrophone",
                 "SEAGULL_HOST": "http://api-private:3000/metadata",
                 "SHORELINE_HOST": "http://api-private:3000/auth",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 Hydrophone is the module responsible for sending emails.
 This API sends notifications to users for things like forgotten passwords, initial signup, and invitations.
 
+## 1.9.4 - 2022-04-26
+- Send a simple text version of the message instead of the default warning. Useful for tests and for simple mail clients.
+
 ## 1.9.3 - 2022-02-22
 ### Engineering
 - Build multi-architecture docker images

--- a/clients/sesNotifier.go
+++ b/clients/sesNotifier.go
@@ -10,6 +10,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ses"
+	"github.com/k3a/html2text"
 )
 
 const (
@@ -98,6 +99,8 @@ func (c *SesNotifier) getSesTags(tags map[string]string) []*ses.MessageTag {
 
 // Send a message to a list of recipients with a given subject
 func (c *SesNotifier) Send(to []string, subject string, msg string, tags map[string]string) (int, string) {
+	simpleText := html2text.HTML2Text(msg)
+
 	var toAwsAddress = make([]*string, len(to))
 	for i, x := range to {
 		toAwsAddress[i] = aws.String(x)
@@ -122,7 +125,7 @@ func (c *SesNotifier) Send(to []string, subject string, msg string, tags map[str
 				},
 				Text: &ses.Content{
 					Charset: aws.String(CharSet),
-					Data:    aws.String(DefaultTextMessage),
+					Data:    aws.String(simpleText),
 				},
 			},
 			Subject: &ses.Content{

--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	github.com/google/uuid v1.1.2 // indirect
 	github.com/gorilla/css v1.0.0 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
+	github.com/k3a/html2text v1.0.8 // indirect
 	github.com/klauspost/compress v1.13.6 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -218,6 +218,8 @@ github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/X
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
+github.com/k3a/html2text v1.0.8 h1:rVanLhKilpnJUJs/CNKWzMC4YaQINGxK0rSG8ssmnV0=
+github.com/k3a/html2text v1.0.8/go.mod h1:ieEXykM67iT8lTvEWBh6fhpH4B23kB9OMKPdIBmgUqA=
 github.com/karrick/godirwalk v1.8.0/go.mod h1:H5KPZjojv4lE+QYImBI8xVtrBRgYrIVsaRPx4tDPEn4=
 github.com/karrick/godirwalk v1.10.3/go.mod h1:RoGL9dQei4vP9ilrpETWE8CLOZ1kiN0LhBygSwrAsHA=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=


### PR DESCRIPTION
Ses offers a way to send a simple text version of the email. Let's use this feature and no longer send the default value "You need an HTML client to read this email."

The solution is to extract the text from the html mail.